### PR TITLE
Update houndstooth reference

### DIFF
--- a/lib/allinson_flex.rb
+++ b/lib/allinson_flex.rb
@@ -11,7 +11,7 @@ module AllinsonFlex
                     :m3_schema_version_tag
 
     self.m3_schema_repository_raw = 'https://raw.githubusercontent.com/samvera-labs/houndstooth'
-    self.m3_schema_version_tag = 'f753864727a0ba743cb5ec47e88797435a0a596a'
+    self.m3_schema_version_tag = 'main'
 
     def webpacker
       @webpacker ||= ::Webpacker::Instance.new(

--- a/lib/generators/allinson_flex/templates/config/initializers/allinson_flex.rb
+++ b/lib/generators/allinson_flex/templates/config/initializers/allinson_flex.rb
@@ -9,6 +9,6 @@ AllinsonFlex.setup do |config|
   # Use a different version (eg. commit hash)
   # Default:
   #
-  # config.m3_schema_version_tag = 'f753864727a0ba743cb5ec47e88797435a0a596a'
+  # config.m3_schema_version_tag = 'main'
 end
 Hyrax::CurationConcern.actor_factory.insert_before Hyrax::Actors::ModelActor, AllinsonFlex::DynamicSchemaActor


### PR DESCRIPTION
This PR points the houndstooth's schema version to main. 

Previously it was pointing to a specific version/branch of houndstooth. This is because Julie had her own branch, but it never got merged back to main. 

It has since been merged: https://github.com/samvera-labs/houndstooth/pull/33 hence the updates to its references.