### PR TITLE
I212 - In an AllinsonFlex profile, edit property visibility (with an admin_only check)

### DIFF
--- a/app/controllers/concerns/allinson_flex/dynamic_catalog_behavior.rb
+++ b/app/controllers/concerns/allinson_flex/dynamic_catalog_behavior.rb
@@ -18,8 +18,12 @@ module AllinsonFlex
                 label: label
               }
 
+              if prop.indexing.include?("admin_only")
+                index_args[:if] = lambda { |context, _field_config, _document| context.try(:current_user)&.admin? }
+              end
+
               if prop.indexing.include?("facetable")
-                index_args[:link_to_search] = "#{prop.name.to_s}}_sim"
+                index_args[:link_to_facet] = "#{prop.name.to_s}}_sim"
               end
 
               name = "#{prop.name.to_s}}_tesim"
@@ -30,8 +34,12 @@ module AllinsonFlex
 
             if prop.indexing.include?("facetable")
               name = "#{prop.name.to_s}}_sim"
+              facet_args = { label: label }
+              if prop.indexing.include?("admin_only")
+                facet_args[:if] = lambda { |context, _field_config, _document| context.try(:current_user)&.admin? }
+              end
               unless blacklight_config.facet_fields[name].present?
-                blacklight_config.add_facet_field(name, label: label)
+                blacklight_config.add_facet_field(name, **facet_args)
               end
             end
           end

--- a/app/models/allinson_flex/profile_property.rb
+++ b/app/models/allinson_flex/profile_property.rb
@@ -16,7 +16,8 @@ module AllinsonFlex
     validate :validate_indexing
 
     # array of valid values for indexing
-    INDEXING = %w[displayable
+    INDEXING = %w[admin_only
+                  displayable
                   facetable
                   searchable
                   sortable
@@ -24,6 +25,12 @@ module AllinsonFlex
                   stored_sortable
                   symbol
                   fulltext_searchable].freeze
+
+    def self.included(base)
+      base.class_eval do
+        const_set(:INDEXING, INDEXING)
+      end
+    end
 
     private
 

--- a/app/models/concerns/allinson_flex/dynamic_metadata_behavior.rb
+++ b/app/models/concerns/allinson_flex/dynamic_metadata_behavior.rb
@@ -92,7 +92,7 @@ module AllinsonFlex
       # clear memoizaiton when as_id changes
       old_as_id = @as_id
       
-      @as_id = args[:as_id] || try(:admin_set_id) || AdminSet::DEFAULT_ID
+      @as_id = args[:as_id] || admin_set_id || AdminSet::DEFAULT_ID
       @dynamic_schema_service = nil if old_as_id != @as_id
 
       # If we want to update, dont pass an existing id in

--- a/app/models/concerns/allinson_flex/dynamic_metadata_behavior.rb
+++ b/app/models/concerns/allinson_flex/dynamic_metadata_behavior.rb
@@ -91,7 +91,8 @@ module AllinsonFlex
     def dynamic_schema_service(args = {})
       # clear memoizaiton when as_id changes
       old_as_id = @as_id
-      @as_id = args[:as_id] || admin_set_id || AdminSet::DEFAULT_ID
+      
+      @as_id = args[:as_id] || try(:admin_set_id) || AdminSet::DEFAULT_ID
       @dynamic_schema_service = nil if old_as_id != @as_id
 
       # If we want to update, dont pass an existing id in

--- a/app/services/allinson_flex/dynamic_schema_service.rb
+++ b/app/services/allinson_flex/dynamic_schema_service.rb
@@ -88,9 +88,8 @@ module AllinsonFlex
         indexers[prop_name] = if prop_value[:indexing].blank?
                                 ["#{prop_name}#{default_indexing}"]
                               else
-                                prop_value[:indexing].map do |indexing_key|
-                                  "#{prop_name}#{index_as(indexing_key)}"
-                                end
+                                "#{prop_name}#{index_as(indexing_key)}" if index_as(indexing_key)
+                              end.compact.uniq
         end
       end
       indexers[:profile_version] = ['profile_version_ssi']
@@ -200,6 +199,8 @@ module AllinsonFlex
       # @todo comine with data type to determine indexing value
       def index_as(indexing_key)
         case indexing_key
+        when 'admin_only'
+          nil
         when 'stored_searchable'
           '_tesim'
         when 'facetable'

--- a/app/services/allinson_flex/dynamic_schema_service.rb
+++ b/app/services/allinson_flex/dynamic_schema_service.rb
@@ -112,7 +112,7 @@ module AllinsonFlex
     # @return [Array] hashes of property => label
     def view_properties
       property_keys.map do |prop|
-        { prop => { label: property_locale(prop, 'label') } }
+        { prop => { label: property_locale(prop, 'label'), admin_only: admin_only_for(prop) } }
       end.inject(:merge)
     end
 
@@ -155,6 +155,10 @@ module AllinsonFlex
 
       def properties
         @properties ||= dynamic_schema.schema.deep_symbolize_keys![:properties]
+      end
+
+      def admin_only_for(property)
+        property_hash_for(property)[:indexing]&.include?('admin_only')
       end
 
       def required_for(property)

--- a/lib/generators/allinson_flex/templates/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/lib/generators/allinson_flex/templates/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,4 +1,5 @@
 <% presenter.dynamic_schema_service.view_properties.each_pair do | prop_key, prop_value | %>
   <%# @todo internationalisation %>
+  <% next if prop_value[:admin_only] && !presenter.current_ability.current_user.admin? %>
   <%= presenter.attribute_to_html(prop_key, label: prop_value[:label] ,html_dl: true) %>
 <% end %>

--- a/lib/generators/allinson_flex/templates/config/metadata_profile/default_schema.json
+++ b/lib/generators/allinson_flex/templates/config/metadata_profile/default_schema.json
@@ -443,6 +443,7 @@
             "items": {
               "type": "string",
               "enum": [
+                "admin_only",
                 "displayable",
                 "facetable",
                 "searchable",


### PR DESCRIPTION
Pulled over work done by IU: https://github.com/IU-Libraries-Joint-Development/essi/pull/344/commits

ref: https://gitlab.com/notch8/utk-hyku/-/issues/212

# Summary

This work was done by Indiana University. 

!! Possible breaking change: the app using Allinson Flex needs to define a admin? method

# Acceptance Criteria

- [ ] non admin users should not see properties that are marked as admin_only, in the metadata profile. 

# Screenshots or Video

**admin_only indexing was added to rights_statement**

AS A LOGGED OUT USER: 
<img width="1274" alt="Screen Shot 2022-10-13 at 4 39 47 PM" src="https://user-images.githubusercontent.com/10081604/195731116-f0fe918e-6922-4478-808f-8aba9b74860e.png">


AS AN LOGGED IN ADMIN USER: 
<img width="989" alt="Screen Shot 2022-10-13 at 4 03 31 PM" src="https://user-images.githubusercontent.com/10081604/195731129-387b7e7a-d3af-4ac6-9087-7e91f4bd43ba.png">


# Testing Instructions

1. add admin_only and displayable indexing to a property in the metadata yaml profile
2. create a work. fill in data for that admin_only property. 
- [ ] When a user is logged in as an admin, they should see that property on the work's show page
- [ ] When a user is logged out, they should not see that admin_only property

