### PR TITLE
i216 - enable ability to pass model_name args to works generator cli command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ and click Import Profile. You can select the example profile in config/metadata_
 $ rails generate allinson_flex:works
 ```
 
-To run the generator against specific models, pass the command an argument like: 
+To run the generator against specific models, pass the command a model_name argument like: 
 
 ```bash
 $ rails generate allinson_flex:works image
 ```
 
-and for mulitple models...
+You can pass it multiple arguments for mulitple models, like:
 
 ```bash
 $ rails generate allinson_flex:works audio book

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ rails generate allinson_flex:works image
 You can pass it multiple arguments for mulitple models, like:
 
 ```bash
-$ rails generate allinson_flex:works audio book
+$ rails generate allinson_flex:works image book
 ```
 
 You must restart rails after generating work classes

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ and click Import Profile. You can select the example profile in config/metadata_
 $ rails generate allinson_flex:works
 ```
 
+To run the generator against specific models, pass the command an argument like: 
+
+```bash
+$ rails generate allinson_flex:works image
+```
+
+and for mulitple models...
+
+```bash
+$ rails generate allinson_flex:works audio book
+```
+
 You must restart rails after generating work classes
 
 ## Contributing

--- a/lib/generators/allinson_flex/works_generator.rb
+++ b/lib/generators/allinson_flex/works_generator.rb
@@ -2,6 +2,7 @@
 
 class AllinsonFlex::WorksGenerator < Rails::Generators::Base
   source_root File.expand_path('../templates', __FILE__)
+  argument :model_name, type: :array, default: []
   class_option :include_module, type: :string, default: nil
 
   desc 'This generator configures works to use AllinsonFlex.'
@@ -14,7 +15,7 @@ class AllinsonFlex::WorksGenerator < Rails::Generators::Base
     # check if this is a hyku application
     switch!(Account.first) if defined? Account
 
-    @work_types = AllinsonFlex::DynamicSchema.all.map(&:allinson_flex_class).uniq
+    @work_types = model_name.presence.map(&:titleize) || AllinsonFlex::DynamicSchema.all.map(&:allinson_flex_class).uniq
     @curation_concerns = Hyrax.config.curation_concerns.map(&:to_s)
     if @work_types.blank?
       say_status("error", "No AllinsonFlex Classes have been defined. Please load or create a Profile.", :red)


### PR DESCRIPTION

Scenario: When you need to run the AllinsonFlex on a newly added model. Now you can pass the model name to the generator command to prevent it from re running it on pre-existing models.

ie: rails generate allinson_flex:works image

You can also pass it multiple model names.

ie: rails generate allinson_flex:works audio book

If you don't pass it argument, it will run the generator against all models/work types