### PR TITLE
Remove Basic metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ $ rails db:migrate
 
 AllinsonFlex uses webpacker and React JS (via the react-rails gem).
 
-Please run the following if they are not already installed in your application:
+Please run the following if they are not already installed in your application. 
+Note: If running a docker container, these need to be installed outside of the container in order to find the github ssh links.
 
 ```bash
 $ rails webpacker:install
@@ -79,6 +80,8 @@ Overwrite /app/samvera/hyrax-webapp/app/views/hyrax/base/_attribute_rows.html.er
 ```
 
 You must restart rails after generating work classes.
+
+Note: When used together, AllinsonFlex and Bulkrax cause conflicting uses of the `app/views/hyrax/dashboard/sidebar/_repository_content.html.erb` partial. The install generator attempts to handle this, but they may require a manual override.
 
 ## Contributing
 See

--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ and to app/assets/javascripts/application.js
 Open the app in a browser and navigate to the Hyrax Dashboard > Metadata Profiles
 and click Import Profile. You can select the example profile in config/metadata_profile/hyrax.yaml
 
-
 ### Create work types
+
+The work type installer can run over existing work models or generate new ones. 
+
+Add or modify all existing work types, based on Hyrax curation concerns or Dynamic Shemas:
 
 ```bash
 $ rails generate allinson_flex:works
@@ -60,16 +63,22 @@ $ rails generate allinson_flex:works
 To run the generator against specific models, pass the command a model_name argument like: 
 
 ```bash
-$ rails generate allinson_flex:works image
+$ rails generate allinson_flex:works Image
 ```
 
 You can pass it multiple arguments for mulitple models, like:
 
 ```bash
-$ rails generate allinson_flex:works image book
+$ rails generate allinson_flex:works Image Book GenericWork
 ```
 
-You must restart rails after generating work classes
+Accept the overwrite when requested: 
+
+```
+Overwrite /app/samvera/hyrax-webapp/app/views/hyrax/base/_attribute_rows.html.erb? (enter "h" for help) [Ynaqdhm]
+```
+
+You must restart rails after generating work classes.
 
 ## Contributing
 See

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gem 'allinson_flex', git: 'https://github.com/samvera-labs/allinson_flex.git'
 
 And then execute:
 ```bash
-$ bundle update
+$ bundle install
 $ rails generate allinson_flex:install
 $ rails db:migrate
 ```

--- a/app/models/allinson_flex/profile_class.rb
+++ b/app/models/allinson_flex/profile_class.rb
@@ -4,6 +4,8 @@ module AllinsonFlex
   class ProfileClass < ApplicationRecord
     # @todo any before_destroy validation?
     # many to many relationship between class and context
+    #   Note: this seems incorrect, as has_and_belongs_to_many is not defined on both models, 
+    #   and additionally there is a defined table, ProfileClassContext as the intersection of these two classes.
     has_and_belongs_to_many :profile_contexts # this seems incorrect??
     has_many :available_properties, as: :available_on, class_name: 'AllinsonFlex::ProfileAvailableProperty', dependent: :destroy
     has_many :properties, through: :available_properties, source: :profile_property

--- a/app/models/allinson_flex/profile_class.rb
+++ b/app/models/allinson_flex/profile_class.rb
@@ -4,7 +4,7 @@ module AllinsonFlex
   class ProfileClass < ApplicationRecord
     # @todo any before_destroy validation?
     # many to many relationship between class and context
-    has_and_belongs_to_many :profile_contexts
+    has_and_belongs_to_many :profile_contexts # this seems incorrect??
     has_many :available_properties, as: :available_on, class_name: 'AllinsonFlex::ProfileAvailableProperty', dependent: :destroy
     has_many :properties, through: :available_properties, source: :profile_property
     has_many :class_texts, as: :textable, class_name: 'AllinsonFlex::ProfileText', dependent: :destroy

--- a/app/models/allinson_flex/profile_class_context.rb
+++ b/app/models/allinson_flex/profile_class_context.rb
@@ -2,6 +2,7 @@
 
 module AllinsonFlex
   class ProfileClassContext < ApplicationRecord
+    self.table_name = 'allinson_flex_profile_classes_contexts'
     belongs_to :profile_class, required: false
     belongs_to :profile_context, required: false
   end

--- a/app/models/concerns/allinson_flex/dynamic_metadata_behavior.rb
+++ b/app/models/concerns/allinson_flex/dynamic_metadata_behavior.rb
@@ -69,6 +69,8 @@ module AllinsonFlex
 
     def load_allinson_flex
       dynamic_schema.schema['properties'].each do |prop, value|
+        # do not override if part of AllinsonFlex::FoundationalMetadata
+        next if attributes_not_defined_dynamically.include?(prop.to_sym)
         predicate = value['predicate'].presence || "https://localhost/#{prop}"
         self.class.late_add_property prop.to_sym, predicate: predicate, multiple: !value['singular']
       end
@@ -91,7 +93,6 @@ module AllinsonFlex
     def dynamic_schema_service(args = {})
       # clear memoizaiton when as_id changes
       old_as_id = @as_id
-      
       @as_id = args[:as_id] || admin_set_id || AdminSet::DEFAULT_ID
       @dynamic_schema_service = nil if old_as_id != @as_id
 

--- a/app/models/concerns/allinson_flex/foundational_metadata.rb
+++ b/app/models/concerns/allinson_flex/foundational_metadata.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module AllinsonFlex
+  # Defines properties from Hyrax's BasicMetadata which can not yet be defined dynamically
+  # @todo: test if AllinsonFlex can define these dynamically
+  #   if not, document why, and if so, remove
+  module FoundationalMetadata
+    extend ActiveSupport::Concern
+
+    included do
+      # properties which should not override standard definition even if included in the yaml
+      class_attribute :attributes_not_defined_dynamically
+      self.attributes_not_defined_dynamically = [:based_near, :label]
+
+      # Any terms defined here are in the model but not actually available to the app unless they are
+      #   1) included in metadata_profile.yml OR 
+      #   2) included in base terms in dynamic_form_behavior
+
+      # unsure how/if this is used - possibly indicates the name to be used when downloading a datastream's contents??
+      # Does not work to define in yaml, apparently because of predicate
+      property :label, predicate: ActiveFedora::RDF::Fcrepo::Model.downloadFilename, multiple: false
+
+      # For property :based_near -- required by & requires "include Hyrax::IndexesLinkedMetadata"
+      property :keyword, predicate: ::RDF::Vocab::SCHEMA.keywords # must be present, but doesn't need to override yaml.
+      property :based_near, predicate: ::RDF::Vocab::FOAF.based_near, class_name: Hyrax::ControlledVocabularies::Location
+
+      id_blank = proc { |attributes| attributes[:id].blank? }
+      class_attribute :controlled_properties
+      self.controlled_properties = [:based_near]
+      accepts_nested_attributes_for :based_near, reject_if: id_blank, allow_destroy: true
+    end
+  end
+end

--- a/lib/generators/allinson_flex/install_generator.rb
+++ b/lib/generators/allinson_flex/install_generator.rb
@@ -120,7 +120,7 @@ class AllinsonFlex::InstallGenerator < Rails::Generators::Base
  
       unless file_text.include?(menu_text)
         if file_text.include?("<%= render 'hyrax/dashboard/sidebar/menu_partials'")
-          insert_into_file, file, "\n#{insert_text}", before: "<%= render 'hyrax/dashboard/sidebar/menu_partials'"
+          insert_into_file file, "\n#{insert_text}", before: "<%= render 'hyrax/dashboard/sidebar/menu_partials'"
         else
           append_file file, "\n#{insert_text}"
         end

--- a/lib/generators/allinson_flex/install_generator.rb
+++ b/lib/generators/allinson_flex/install_generator.rb
@@ -120,7 +120,7 @@ class AllinsonFlex::InstallGenerator < Rails::Generators::Base
  
       unless file_text.include?(menu_text)
         if file_text.include?("<%= render 'hyrax/dashboard/sidebar/menu_partials'")
-          insert_into_file file, "\n#{insert_text}", before: "<%= render 'hyrax/dashboard/sidebar/menu_partials'"
+          insert_into_file file, "#{insert_text}\n", before: "<%= render 'hyrax/dashboard/sidebar/menu_partials'"
         else
           append_file file, "\n#{insert_text}"
         end

--- a/lib/generators/allinson_flex/install_generator.rb
+++ b/lib/generators/allinson_flex/install_generator.rb
@@ -121,7 +121,7 @@ class AllinsonFlex::InstallGenerator < Rails::Generators::Base
 
       unless file_text.include?(menu_text)
         if file_text.include?(location_text)
-          insert_into_file, file, before: insert_text do
+          insert_into_file, file, before: /#{location_text}/ do
             "\n#{insert_text}"
           end
         else

--- a/lib/generators/allinson_flex/install_generator.rb
+++ b/lib/generators/allinson_flex/install_generator.rb
@@ -117,11 +117,10 @@ class AllinsonFlex::InstallGenerator < Rails::Generators::Base
       file_text = File.read(file)
       menu_text = '<%= menu.nav_link(allinson_flex.profiles_path) do %>'
       insert_text = "<% if current_user.can? :manage, AllinsonFlex::Profile %>\n  <%= menu.nav_link(allinson_flex.profiles_path) do %>\n    <span class='fa fa-table' aria-hidden='true'></span> <span class='sidebar-action-text'><%= t('allinson_flex.admin.sidebar.profiles') %></span>\n  <% end %>\n<% end %>\n"
-      location_text = "<%= render 'hyrax/dashboard/sidebar/menu_partials', menu: menu, section: :repository_content %>"
-
+ 
       unless file_text.include?(menu_text)
-        if file_text.include?(location_text)
-          insert_into_file, file, before: /#{location_text}/ do
+        if file_text.include?("<%= render 'hyrax/dashboard/sidebar/menu_partials'")
+          insert_into_file, file, before: /<%= render 'hyrax\/dashboard\/sidebar\/menu_partials', menu: menu, section: :repository_content %>/ do
             "\n#{insert_text}"
           end
         else

--- a/lib/generators/allinson_flex/install_generator.rb
+++ b/lib/generators/allinson_flex/install_generator.rb
@@ -103,6 +103,14 @@ class AllinsonFlex::InstallGenerator < Rails::Generators::Base
     end
   end
 
+  def remove_indexer
+    file = "app/indexers/app_indexer.rb"
+    file_text = File.read(file)
+    if file_text.include?('  include Hyrax::IndexesBasicMetadata')
+      comment_lines file, /  include Hyrax::IndexesBasicMetadata/
+    end
+  end
+
   def add_gitignore
     lines = [
       '/public/packs',

--- a/lib/generators/allinson_flex/install_generator.rb
+++ b/lib/generators/allinson_flex/install_generator.rb
@@ -117,12 +117,13 @@ class AllinsonFlex::InstallGenerator < Rails::Generators::Base
       file_text = File.read(file)
       insert = "<% if current_user.can? :manage, AllinsonFlex::Profile %>\n
       <%= menu.nav_link(allinson_flex.profiles_path) do %>\n
-        <span class="fa fa-table" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('allinson_flex.admin.sidebar.profiles') %></span>\n
+        <span class='fa fa-table' aria-hidden='true'></span> <span class='sidebar-action-text'><%= t('allinson_flex.admin.sidebar.profiles') %></span>\n
       <% end %>\n
     <% end %>\n"
       unless file_text.include?('<%= menu.nav_link(allinson_flex.profiles_path) do %>')
         append_file file do
-        "\n#{insert}"
+          "\n#{insert}"
+        end
       end
     end
   end

--- a/lib/generators/allinson_flex/install_generator.rb
+++ b/lib/generators/allinson_flex/install_generator.rb
@@ -120,7 +120,7 @@ class AllinsonFlex::InstallGenerator < Rails::Generators::Base
  
       unless file_text.include?(menu_text)
         if file_text.include?("<%= render 'hyrax/dashboard/sidebar/menu_partials'")
-          insert_into_file, file, before: /<%= render 'hyrax\/dashboard\/sidebar\/menu_partials', menu: menu, section: :repository_content %>/ do
+          insert_into_file, file, before: /<%= render 'hyrax\/dashboard\/sidebar\/menu_partials'/ do
             "\n#{insert_text}"
           end
         else

--- a/lib/generators/allinson_flex/install_generator.rb
+++ b/lib/generators/allinson_flex/install_generator.rb
@@ -103,11 +103,27 @@ class AllinsonFlex::InstallGenerator < Rails::Generators::Base
     end
   end
 
-  def remove_indexer
+  def remove_basic_metadata_indexer
     file = "app/indexers/app_indexer.rb"
     file_text = File.read(file)
     if file_text.include?('  include Hyrax::IndexesBasicMetadata')
       comment_lines file, /include Hyrax::IndexesBasicMetadata/
+    end
+  end
+
+  def add_sidebar_menu_option
+    file = "app/views/hyrax/dashboard/sidebar/_repository_content.html.erb"
+    if File.exist?(file)
+      file_text = File.read(file)
+      insert = "<% if current_user.can? :manage, AllinsonFlex::Profile %>\n
+      <%= menu.nav_link(allinson_flex.profiles_path) do %>\n
+        <span class="fa fa-table" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('allinson_flex.admin.sidebar.profiles') %></span>\n
+      <% end %>\n
+    <% end %>\n"
+      unless file_text.include?('<%= menu.nav_link(allinson_flex.profiles_path) do %>')
+        append_file file do
+        "\n#{insert}"
+      end
     end
   end
 

--- a/lib/generators/allinson_flex/install_generator.rb
+++ b/lib/generators/allinson_flex/install_generator.rb
@@ -115,14 +115,19 @@ class AllinsonFlex::InstallGenerator < Rails::Generators::Base
     file = "app/views/hyrax/dashboard/sidebar/_repository_content.html.erb"
     if File.exist?(file)
       file_text = File.read(file)
-      insert = "<% if current_user.can? :manage, AllinsonFlex::Profile %>\n
-      <%= menu.nav_link(allinson_flex.profiles_path) do %>\n
-        <span class='fa fa-table' aria-hidden='true'></span> <span class='sidebar-action-text'><%= t('allinson_flex.admin.sidebar.profiles') %></span>\n
-      <% end %>\n
-    <% end %>\n"
-      unless file_text.include?('<%= menu.nav_link(allinson_flex.profiles_path) do %>')
-        append_file file do
-          "\n#{insert}"
+      menu_text = '<%= menu.nav_link(allinson_flex.profiles_path) do %>'
+      insert_text = "<% if current_user.can? :manage, AllinsonFlex::Profile %>\n  <%= menu.nav_link(allinson_flex.profiles_path) do %>\n    <span class='fa fa-table' aria-hidden='true'></span> <span class='sidebar-action-text'><%= t('allinson_flex.admin.sidebar.profiles') %></span>\n  <% end %>\n<% end %>\n"
+      location_text = "<%= render 'hyrax/dashboard/sidebar/menu_partials', menu: menu, section: :repository_content %>"
+
+      unless file_text.include?(menu_text)
+        if file_text.include?(location_text)
+          insert_into_file, file, before: insert_text do
+            "\n#{insert_text}"
+          end
+        else
+          append_file file do
+            "\n#{insert_text}"
+          end
         end
       end
     end

--- a/lib/generators/allinson_flex/install_generator.rb
+++ b/lib/generators/allinson_flex/install_generator.rb
@@ -120,13 +120,9 @@ class AllinsonFlex::InstallGenerator < Rails::Generators::Base
  
       unless file_text.include?(menu_text)
         if file_text.include?("<%= render 'hyrax/dashboard/sidebar/menu_partials'")
-          insert_into_file, file, before: /<%= render 'hyrax\/dashboard\/sidebar\/menu_partials'/ do
-            "\n#{insert_text}"
-          end
+          insert_into_file, file, "\n#{insert_text}", before: "<%= render 'hyrax/dashboard/sidebar/menu_partials'"
         else
-          append_file file do
-            "\n#{insert_text}"
-          end
+          append_file file, "\n#{insert_text}"
         end
       end
     end

--- a/lib/generators/allinson_flex/install_generator.rb
+++ b/lib/generators/allinson_flex/install_generator.rb
@@ -107,7 +107,7 @@ class AllinsonFlex::InstallGenerator < Rails::Generators::Base
     file = "app/indexers/app_indexer.rb"
     file_text = File.read(file)
     if file_text.include?('  include Hyrax::IndexesBasicMetadata')
-      comment_lines file, /  include Hyrax::IndexesBasicMetadata/
+      comment_lines file, /include Hyrax::IndexesBasicMetadata/
     end
   end
 

--- a/lib/generators/allinson_flex/works_generator.rb
+++ b/lib/generators/allinson_flex/works_generator.rb
@@ -98,11 +98,16 @@ class AllinsonFlex::WorksGenerator < Rails::Generators::Base
         insert_into_file file, before: /  include ::Hyrax::BasicMetadata/ do
           "\n#{insert}\n"
         end
+        comment_lines file, /  include ::Hyrax::BasicMetadata/
       else
         insert_into_file file, before: /\nend/ do
           "\n#{insert}"
         end
       end
+      insert = '  include AllinsonFlex::FoundationalMetadata'
+      insert_into_file file, before: /\nend/ do
+        "\n#{insert}"
+      end unless file_text.include?(insert)
     end
   end
 

--- a/lib/generators/allinson_flex/works_generator.rb
+++ b/lib/generators/allinson_flex/works_generator.rb
@@ -86,12 +86,6 @@ class AllinsonFlex::WorksGenerator < Rails::Generators::Base
         "\n#{insert}\n"
       end
     end
-
-    file = "app/indexers/app_indexer.rb"
-    file_text = File.read(file)
-    if file_text.include?('  include Hyrax::IndexesBasicMetadata')
-      comment_lines file, /  include Hyrax::IndexesBasicMetadata/
-    end
   end
 
   def configure_models

--- a/lib/generators/allinson_flex/works_generator.rb
+++ b/lib/generators/allinson_flex/works_generator.rb
@@ -86,6 +86,12 @@ class AllinsonFlex::WorksGenerator < Rails::Generators::Base
         "\n#{insert}\n"
       end
     end
+
+    file = "app/indexers/app_indexer.rb"
+    file_text = File.read(file)
+    if file_text.include?('  include Hyrax::IndexesBasicMetadata')
+      comment_lines file, /  include Hyrax::IndexesBasicMetadata/
+    end
   end
 
   def configure_models

--- a/lib/generators/allinson_flex/works_generator.rb
+++ b/lib/generators/allinson_flex/works_generator.rb
@@ -15,7 +15,7 @@ class AllinsonFlex::WorksGenerator < Rails::Generators::Base
     # check if this is a hyku application
     switch!(Account.first) if defined? Account
 
-    @work_types = model_name.presence.map(&:titleize) || AllinsonFlex::DynamicSchema.all.map(&:allinson_flex_class).uniq
+    @work_types = model_name.presence&.map(&:to_s)&.map(&:camelcase) || AllinsonFlex::DynamicSchema.all.map(&:allinson_flex_class).uniq
     @curation_concerns = Hyrax.config.curation_concerns.map(&:to_s)
     if @work_types.blank?
       say_status("error", "No AllinsonFlex Classes have been defined. Please load or create a Profile.", :red)
@@ -84,6 +84,9 @@ class AllinsonFlex::WorksGenerator < Rails::Generators::Base
       next if file_text.include?(insert)
       insert_into_file file, before: /\nend/ do
         "\n#{insert}\n"
+      end
+      if file_text.include?('  include Hyrax::IndexesBasicMetadata')
+        comment_lines file, /include Hyrax::IndexesBasicMetadata/
       end
     end
   end

--- a/lib/generators/allinson_flex/works_generator.rb
+++ b/lib/generators/allinson_flex/works_generator.rb
@@ -98,7 +98,7 @@ class AllinsonFlex::WorksGenerator < Rails::Generators::Base
         insert_into_file file, before: /  include ::Hyrax::BasicMetadata/ do
           "\n#{insert}\n"
         end
-        comment_lines file, /  include ::Hyrax::BasicMetadata/
+        comment_lines file, /include ::Hyrax::BasicMetadata/
       else
         insert_into_file file, before: /\nend/ do
           "\n#{insert}"


### PR DESCRIPTION
Fixes https://github.com/scientist-softserv/utk-hyku/issues/131:
- Modifies installers to handle removing BasicMetadata and IndexesBasicMetadata
- Adds FoundationalMetadata to include only those attributes which cannot be defined via the metadata modeling yaml file

Other fixes:
- Modifies install generator to handle adding menu option if needed (Bulkrax adds the menu to the app, so menu here was not being reached)
- Modifies work generator to correct https://github.com/samvera-labs/allinson_flex/pull/102



