### PR TITLE
parses controlled_values for better handling

### DIFF
--- a/app/services/allinson_flex/allinson_flex_constructor.rb
+++ b/app/services/allinson_flex/allinson_flex_constructor.rb
@@ -192,7 +192,7 @@ module AllinsonFlex
                   'required' => required?(property.try(:requirement), property.cardinality_minimum),
                   'singular' => singular?(property.try(:multi_value), property.cardinality_maximum),
                   'indexing' => property.indexing,
-                  'controlled_values' => property.controlled_value_sources,
+                  'controlled_values' => JSON.parse(property.controlled_value_sources),
                   'range' => property.range,
                   'mappings' => property.mappings
                 }.compact


### PR DESCRIPTION
Without parsing, the values of controlled values comes across as follows: 

`"[\"null\"]"`

This change will happen at the source where the values get saved, which then allows for better handling of it later. 

`"[\"null\"]" => ["null"]`