### PR TITLE
Fix typo in dynamic_catalog_behavior

### DIFF
--- a/app/controllers/concerns/allinson_flex/dynamic_catalog_behavior.rb
+++ b/app/controllers/concerns/allinson_flex/dynamic_catalog_behavior.rb
@@ -33,7 +33,7 @@ module AllinsonFlex
             end
 
             if prop.indexing.include?("facetable")
-              name = "#{prop.name.to_s}}_sim"
+              name = "#{prop.name.to_s}_sim"
               facet_args = { label: label }
               if prop.indexing.include?("admin_only")
                 facet_args[:if] = lambda { |context, _field_config, _document| context.try(:current_user)&.admin? }


### PR DESCRIPTION
# Summary
The changes in this pull request will fix the functionality of the facets by correcting the typo of an additional '}' in the string
interpolation of line 36.

# Screenshots
<details>

- Facet behavior with typo
![Facet behavior with typo](https://github.com/samvera-labs/allinson_flex/assets/95306716/be54961a-e6e1-4c1f-baf2-3ebf3ff8fcfa)

- Facet behavior with fix
![Functioning Facets](https://github.com/samvera-labs/allinson_flex/assets/95306716/59c72351-1687-4389-b88e-8a7ac5d7bdc0)

- When clicking on facet link to filter
![Clicking Facet Link](https://github.com/samvera-labs/allinson_flex/assets/95306716/46c740a7-2062-4af9-aab5-b10d691a94bb)
</details>
