### PR TITLE
Fix typos

### DIFF
--- a/app/controllers/concerns/allinson_flex/dynamic_catalog_behavior.rb
+++ b/app/controllers/concerns/allinson_flex/dynamic_catalog_behavior.rb
@@ -23,10 +23,10 @@ module AllinsonFlex
               end
 
               if prop.indexing.include?("facetable")
-                index_args[:link_to_facet] = "#{prop.name.to_s}}_sim"
+                index_args[:link_to_facet] = "#{prop.name.to_s}_sim"
               end
 
-              name = "#{prop.name.to_s}}_tesim"
+              name = "#{prop.name.to_s}_tesim"
               unless blacklight_config.index_fields[name].present?
                 blacklight_config.add_index_field(name, index_args)
               end


### PR DESCRIPTION
This commit will fix some typos in the `DynamicCatalogBehavior`.