### PR TITLE
Make list works image alt text dynamic

### DIFF
--- a/app/views/hyrax/dashboard/works/_list_works.html.erb
+++ b/app/views/hyrax/dashboard/works/_list_works.html.erb
@@ -7,7 +7,11 @@
   <td>
     <div class='media'>
       <%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
-        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+        <% if document.thumbnail_id.nil? %>
+          <%= image_tag default_work_image, { class: 'hidden-xs file_listing_thumbnail', alt: 'Default work thumbnail' } %>
+        <% else %>
+          <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail', alt: block_for(name: 'default_work_image_text') }, { suppress_link: true } %>
+        <% end %>
       <% end %>
 
       <div class='media-body'>

--- a/app/views/hyrax/my/works/_list_works.html.erb
+++ b/app/views/hyrax/my/works/_list_works.html.erb
@@ -9,7 +9,11 @@
   <td>
     <div class='media'>
       <%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
-        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+        <% if document.thumbnail_id.nil? %>
+          <%= image_tag default_work_image, { class: 'hidden-xs file_listing_thumbnail', alt: 'Default work thumbnail' } %>
+        <% else %>
+          <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail', alt: block_for(name: 'default_work_image_text') }, { suppress_link: true } %>
+        <% end %>
       <% end %>
 
       <div class='media-body'>


### PR DESCRIPTION
This commit will make the listed works on the dashboard respect the alt text set through the appearance tab in the admin dashboard.

<img width="609" alt="image" src="https://github.com/samvera-labs/allinson_flex/assets/19597776/66135bcd-5026-4845-9516-91d73613ac04">
