### PR TITLE
Add title attribute

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_allinson_flex_sidebar_additions.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_allinson_flex_sidebar_additions.html.erb
@@ -1,5 +1,6 @@
 <% if current_ability.admin? %>
-  <%= menu.nav_link(allinson_flex.profiles_path) do %>
+  <%= menu.nav_link(allinson_flex.profiles_path,
+                    title: t('allinson_flex.admin.sidebar.profiles')) do %>
     <span class="fa fa-table" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('allinson_flex.admin.sidebar.profiles') %></span>
   <% end %>
 <% end %>


### PR DESCRIPTION
This commit will add the `title` attribute to the list tags so when users hover over the links they will see the name of the link on the dashboard.

<img width="196" alt="image" src="https://github.com/samvera-labs/allinson_flex/assets/19597776/1bbd234f-0ccc-45ca-a85f-c7513c1de5ac">