### PR TITLE
🐛 Fix logic for displaying custom alt text

### DIFF
--- a/app/views/hyrax/dashboard/works/_list_works.html.erb
+++ b/app/views/hyrax/dashboard/works/_list_works.html.erb
@@ -7,11 +7,7 @@
   <td>
     <div class='media'>
       <%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
-        <% if document.thumbnail_id.nil? %>
-          <%= image_tag default_work_image, { class: 'hidden-xs file_listing_thumbnail', alt: 'Default work thumbnail' } %>
-        <% else %>
-          <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail', alt: block_for(name: 'default_work_image_text') }, { suppress_link: true } %>
-        <% end %>
+        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail', alt: block_for(name: 'default_work_image_text') || "#{document.title_or_label} #{t('hyrax.homepage.admin_sets.thumbnail')}" }, { suppress_link: true } %>
       <% end %>
 
       <div class='media-body'>

--- a/app/views/hyrax/my/works/_list_works.html.erb
+++ b/app/views/hyrax/my/works/_list_works.html.erb
@@ -9,11 +9,7 @@
   <td>
     <div class='media'>
       <%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
-        <% if document.thumbnail_id.nil? %>
-          <%= image_tag default_work_image, { class: 'hidden-xs file_listing_thumbnail', alt: 'Default work thumbnail' } %>
-        <% else %>
-          <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail', alt: block_for(name: 'default_work_image_text') }, { suppress_link: true } %>
-        <% end %>
+        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail', alt: block_for(name: 'default_work_image_text') || "#{document.title_or_label} #{t('hyrax.homepage.admin_sets.thumbnail')}" }, { suppress_link: true } %>
       <% end %>
 
       <div class='media-body'>


### PR DESCRIPTION
This is a rework for displaying the custom alt text for works in the dashboard.  Also the fallback for the text is now aligned with Hyrax

https://github.com/samvera/hyrax/blob/cbdc3194b45d623e68467bca244df2831924d0a7/app/views/hyrax/my/works/_list_works.html.erb#L12

<img width="1360" alt="Pasted image 20230727091111" src="https://github.com/samvera-labs/allinson_flex/assets/19597776/732855a8-9fea-4b56-96be-fd7c7701c228">


<img width="1335" alt="image" src="https://github.com/samvera-labs/allinson_flex/assets/19597776/d5f85f06-88e2-48ae-982f-17986962be8e">
