### PR TITLE
Optimize Profile queries with eager loading

### DIFF
--- a/app/controllers/concerns/allinson_flex/dynamic_catalog_behavior.rb
+++ b/app/controllers/concerns/allinson_flex/dynamic_catalog_behavior.rb
@@ -6,7 +6,7 @@ module AllinsonFlex
 
     class_methods do
       def load_allinson_flex
-        profile = AllinsonFlex::Profile.current_version
+        profile = AllinsonFlex::Profile.includes(properties: :texts).current_version
         unless profile.blank?
           profile.properties.each do |prop|
             # blacklight wants 1 label for all classes with this property


### PR DESCRIPTION
Add includes(properties: :texts) to the Profile.current_version call to reduce N+1 queries when accessing profile properties and their associated texts. This will improve performance by fetching related records in a single query instead of multiple database calls.