### PR TITLE
Use the SolrDocument instead of querying Fedora

### DIFF
--- a/app/helpers/allinson_flex_helper.rb
+++ b/app/helpers/allinson_flex_helper.rb
@@ -19,7 +19,7 @@ module AllinsonFlexHelper
   def available_admin_sets
     # Restrict available_admin_sets to only those current user can desposit to.
     @available_admin_sets ||= Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability, source_type: 'admin_set').map do |admin_set_id|
-      [AdminSet.find(admin_set_id).title.first, admin_set_id]
+      [SolrDocument.find(admin_set_id).title.first, admin_set_id]
     end
   end
 

--- a/app/presenters/concerns/allinson_flex/dynamic_presenter_behavior.rb
+++ b/app/presenters/concerns/allinson_flex/dynamic_presenter_behavior.rb
@@ -18,7 +18,7 @@ module AllinsonFlex
     end
 
     def admin_set_id
-      @admin_set_id ||= AdminSet.where(title: self.admin_set).first&.id
+      @admin_set_id ||= Hyrax::SolrService.query("title_tesim:\"#{self.admin_set.first}\"", rows: 1, fl: 'id').first['id']
     end
 
     def dynamic_schema_service


### PR DESCRIPTION
Instead of querying Fedora on the frontend for the AdminSet, we can use the SolrDocument instead which is more performant.