### PR TITLE
Use context method directly instead of admin set

### DIFF
--- a/app/services/allinson_flex/dynamic_schema_service.rb
+++ b/app/services/allinson_flex/dynamic_schema_service.rb
@@ -135,7 +135,7 @@ module AllinsonFlex
     private
 
       def context_for(admin_set_id:)
-        cxt = AdminSet.find(admin_set_id).metadata_context
+        cxt = AllinsonFlex::Context.find_metadata_context_for(admin_set_id: admin_set_id)
         if cxt.blank?
           raise AllinsonFlex::NoAllinsonFlexContextError.new(
             "No Metadata Context for Admin Set #{admin_set_id}"


### PR DESCRIPTION
This commit will change the way we access the context method in the DynamicSchemaService class.  Instead of going through the admin set, which is a trip to Fedora, we will access the context method directly.